### PR TITLE
corrected typo

### DIFF
--- a/t81_558_class_03_2_pytorch.ipynb
+++ b/t81_558_class_03_2_pytorch.ipynb
@@ -92,7 +92,7 @@
     "PyTorch[[Cite:paszke2019pytorch]](https://arxiv.org/abs/1912.01703) is an open-source software library for machine learning in various kinds of perceptual and language understanding tasks. It is currently used for research and production by different teams at [Meta Platforms](https://about.facebook.com/). Companies have built several pieces of deep learning software on top of PyTorch, including Tesla Autopilot, Uber's Pyro, Hugging Face's Transformers, PyTorch Lightning, and Catalyst. PyTorch provides two high-level features: NumPy-like tensor computing and deep neural networks.\n",
     "\n",
     "- [PyTorch Homepage](https://pytorch.org/)\n",
-    "- [PyTorch GitHib](https://github.com/pytorch/pytorch)\n",
+    "- [PyTorch GitHub](https://github.com/pytorch/pytorch)\n",
     "- [PyTorch Forums](https://discuss.pytorch.org/)\n",
     "\n",
     "## Why PyTorch\n",


### PR DESCRIPTION
[Typo corrected](https://github.com/jeffheaton/app_deep_learning/blob/main/t81_558_class_03_2_pytorch.ipynb) GitHib -> GitHub.